### PR TITLE
Update logging to instantiate winston directly and log json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "web3-core-helpers": "^1.7.4",
     "web3-eth": "^1.7.4",
     "web3-eth-contract": "^1.7.4",
-    "web3-utils": "^1.7.4"
+    "web3-utils": "^1.7.4",
+    "winston": "^3.12.0"
   },
   "devDependencies": {
     "@metamask/eth-sig-util": "^4.0.1",

--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -2,6 +2,7 @@
 import fs from 'fs';
 import Web3 from 'web3';
 import chalk from 'chalk';
+import winston from 'winston';
 import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers';
 import { HttpServer } from './HttpServer';
 import { RelayServer } from './RelayServer';
@@ -168,11 +169,13 @@ async function run(): Promise<void> {
     }
   }
   console.log('Creating server logger...\n');
-  const logger = createServerLogger(
-    config.logLevel,
-    config.loggerUrl,
-    config.loggerUserId
-  );
+  const logger = winston.createLogger({
+    level: 'info',
+    format: winston.format.json(),
+    transports: [
+      new winston.transports.Console(),
+    ]
+  });
   console.log('Creating managers...\n');
   const managerKeyManager = new KeyManager(1, `${workdir}/manager`);
   const workersKeyManager = new KeyManager(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9119,6 +9119,32 @@ winston-transport@^4.5.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
+winston-transport@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.7.0.tgz#e302e6889e6ccb7f383b926df6936a5b781bd1f0"
+  integrity sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.12.0.tgz#a5d965a41d3dc31be5408f8c66e927958846c0d0"
+  integrity sha512-OwbxKaOlESDi01mC9rkM0dQqQt2I8DAUMRLZ/HpbwvDXm85IryEHgoogy5fziQy38PntgZsLlhAYHz//UPHZ5w==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.7.0"
+
 winston@^3.3.3:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.11.0.tgz#2d50b0a695a2758bb1c95279f0a88e858163ed91"


### PR DESCRIPTION
Background:

Fly log shipper was not properly setting the log level which made graphing error rates difficult. This now updates the log output to a json format so we can parse out the log level.

This will also set the default log level to `info`